### PR TITLE
Minor fixes

### DIFF
--- a/define-word.el
+++ b/define-word.el
@@ -44,32 +44,33 @@
   "Define WORD using the Wordnik website."
   (interactive (list (read-string "Word: ")))
   (let ((link (concat "http://wordnik.com/words/" (downcase word))))
-    (url-retrieve
-     link
-     (lambda (status)
-       (let ((err (plist-get status :error)))
-         (if err (error
-                  "\"%s\" %s" link
-                  (downcase (nth 2 (assq (nth 2 err) url-http-codes)))))
-         (let (results beg part)
-           (while (re-search-forward "<li><abbr[^>]*>\\([^<]*\\)</abbr>" nil t)
-             (setq part (match-string 1))
-             (unless (= 0 (length part))
-               (setq part (concat part " ")))
-             (skip-chars-forward " ")
-             (setq beg (point))
-             (when (re-search-forward "</li>")
-               (push (concat (propertize part 'face 'font-lock-keyword-face)
-                             (buffer-substring-no-properties beg (match-beginning 0)))
-                     results)))
-           (setq results (nreverse results))
-           (when (> (length results) define-word-limit)
-             (setq results (cl-subseq results 0 define-word-limit)))
-           (if results
-               (message (mapconcat #'identity results "\n"))
-             (message "0 definitions found")))))
-     nil
-     t t)))
+    (save-match-data
+      (url-retrieve
+       link
+       (lambda (status)
+         (let ((err (plist-get status :error)))
+           (if err (error
+                    "\"%s\" %s" link
+                    (downcase (nth 2 (assq (nth 2 err) url-http-codes)))))
+           (let (results beg part)
+             (while (re-search-forward "<li><abbr[^>]*>\\([^<]*\\)</abbr>" nil t)
+               (setq part (match-string 1))
+               (unless (= 0 (length part))
+                 (setq part (concat part " ")))
+               (skip-chars-forward " ")
+               (setq beg (point))
+               (when (re-search-forward "</li>")
+                 (push (concat (propertize part 'face 'font-lock-keyword-face)
+                               (buffer-substring-no-properties beg (match-beginning 0)))
+                       results)))
+             (setq results (nreverse results))
+             (when (> (length results) define-word-limit)
+               (setq results (cl-subseq results 0 define-word-limit)))
+             (if results
+                 (message (mapconcat #'identity results "\n"))
+               (message "0 definitions found")))))
+       nil
+       t t))))
 
 ;;;###autoload
 (defun define-word-at-point ()
@@ -78,9 +79,9 @@ When the region is active, define the marked phrase."
   (interactive)
   (if (region-active-p)
       (define-word
-          (buffer-substring-no-properties
-           (region-beginning)
-           (region-end)))
+        (buffer-substring-no-properties
+         (region-beginning)
+         (region-end)))
     (define-word (thing-at-point 'word))))
 
 (provide 'define-word)

--- a/define-word.el
+++ b/define-word.el
@@ -82,7 +82,7 @@ When the region is active, define the marked phrase."
         (buffer-substring-no-properties
          (region-beginning)
          (region-end)))
-    (define-word (thing-at-point 'word))))
+    (define-word (thing-at-point 'word t))))
 
 (provide 'define-word)
 


### PR DESCRIPTION
Minor fixes:
- Save match data
- Use `thing-at-point` with no properties

I'm thinking of whether we can add another command called `define-word-dwim`, which combines the `define-word-at-point` and `define-word`. When calling this function with prefix, it will prompt for the user input, but set the initial input to `thing-at-point` or the text in region if region is active. When calling this function without prefix, it will invoke `define-word-at-point`. Do you think this might be useful?
