### PR TITLE
Use `use-region-p' instead of `region-active-p'

### DIFF
--- a/define-word.el
+++ b/define-word.el
@@ -91,7 +91,7 @@ The rule is that all definitions must contain \"Plural of\".")
   "Use `define-word' to define word at point.
 When the region is active, define the marked phrase."
   (interactive)
-  (if (region-active-p)
+  (if (use-region-p)
       (define-word
         (buffer-substring-no-properties
          (region-beginning)


### PR DESCRIPTION
`region-active-p` considers all regions as valid, including empty regions, while `use-region-p` doesn't treat empty regions as valid.

See http://www.gnu.org/software/emacs/manual/html_node/elisp/The-Region.html
