### PR TITLE
Use a default word when prompting

### DIFF
--- a/define-word.el
+++ b/define-word.el
@@ -51,7 +51,7 @@ The rule is that all definitions must contain \"Plural of\".")
 ;;;###autoload
 (defun define-word (word)
   "Define WORD using the Wordnik website."
-  (interactive (list (read-string "Word: ")))
+  (interactive (list (read-string "Word: " (thing-at-point 'word t))))
   (let ((link (concat "http://wordnik.com/words/" (downcase word))))
     (save-match-data
       (url-retrieve


### PR DESCRIPTION
It seems like a good idea to me to fill in the current word as the default when prompting the user.

It helps me have a single binding (just `define-word` instead of `define-word-at-point`) but get the benefit of not having to type in the word entirely. Unlike `define-word-at-point`, it also lets me modify the word being entered.
