### PR TITLE
Add possibility to define multiple services

### DIFF
--- a/define-word.el
+++ b/define-word.el
@@ -5,7 +5,8 @@
 ;; Author: Oleh Krehel <ohwoeowho@gmail.com>
 ;; URL: https://github.com/abo-abo/define-word
 ;; Version: 0.1.0
-;; Package-Requires: ((emacs "24.1"))
+;; Modified: 2017-12-21
+;; Package-Requires: ((emacs "25.1") (request-deferred "0.2.0"))
 ;; Keywords: dictionary, convenience
 
 ;; This file is not part of GNU Emacs
@@ -29,12 +30,15 @@
 ;; to get the definition of word or phrase at point, parse the resulting HTML
 ;; page, and display it with `message'.
 ;;
-;; The HTML page is retrieved asynchronously, using `url-retrieve'.
+;; Extra services can be added by customizing `define-word-services'
+;; where an url, a parsing function, and an (optional) function other
+;; than `message' to display the results can be defined.
+;;
+;; The HTML page is retrieved asynchronously, using `request-deferred'.
 ;;
 ;;; Code:
 
-(require 'url-parse)
-(require 'url-http)
+(require 'request-deferred)
 
 (defgroup define-word nil
   "Define word at point using an online dictionary."
@@ -46,65 +50,115 @@
 
 (defcustom define-word-unpluralize t
   "When non-nil, change the word to singular when appropriate.
-The rule is that all definitions must contain \"Plural of\"."
-  :type 'boolean)
+The rule is that all definitions must contain \"Plural of\".")
 
-(defcustom define-word-url "http://wordnik.com/words/"
-  "URL for looking up words."
-  :type '(choice
-          (const :tag "http" "http://wordnik.com/words/")
-          (const :tag "https" "https://wordnik.com/words/")))
+(defcustom define-word-services
+  '((wordnik "https://wordnik.com/words/%s" define-word--parse-wordnik))
+  "Services for define-word, A list of lists of the
+  format (symbol url function-for-parsing [function-for-display])"
+  :type '(alist :key-type (symbol :tag "Name of service")
+                :value-type (group
+                             (string :tag "Url (%s denotes search word)")
+                             (function :tag "Parsing function")
+                             (choice (const nil) (function :tag "Display function")))))
 
-;;;###autoload
-(defun define-word (word)
-  "Define WORD using the Wordnik website."
-  (interactive (list (read-string "Word: ")))
-  (let ((link (concat define-word-url (downcase word))))
-    (save-match-data
-      (url-retrieve
-       link
-       (lambda (status)
-         (let ((err (plist-get status :error)))
-           (if err (error
-                    "\"%s\" %s" link
-                    (downcase (nth 2 (assq (nth 2 err) url-http-codes)))))
-           (let (results beg part)
-             (while (re-search-forward "<li><abbr[^>]*>\\([^<]*\\)</abbr>" nil t)
-               (setq part (match-string 1))
-               (unless (= 0 (length part))
-                 (setq part (concat part " ")))
-               (skip-chars-forward " ")
-               (setq beg (point))
-               (when (re-search-forward "</li>")
-                 (push (concat (propertize part 'face 'font-lock-keyword-face)
-                               (buffer-substring-no-properties beg (match-beginning 0)))
-                       results)))
-             (setq results (nreverse results))
-             (cond ((= 0 (length results))
-                    (message "0 definitions found"))
-                   ((and define-word-unpluralize
-                         (cl-every (lambda (x) (string-match "[Pp]\\(?:lural\\|l\\.\\).*of \\(.*\\)\\." x))
-                                   results))
-                    (define-word (match-string 1 (car (last results)))))
-                   (t
-                    (when (> (length results) define-word-limit)
-                      (setq results (cl-subseq results 0 define-word-limit)))
-                    (message (mapconcat #'identity results "\n")))))))
-       nil
-       t t))))
+(defcustom define-word-default-service 'wordnik
+  "The default service for define-word commands. Must be one of
+  `define-word-services'")
 
 ;;;###autoload
-(defun define-word-at-point ()
+(defun define-word (word service &optional choose-service)
+  "Define WORD using various services.
+
+By default uses `define-word-default-service', but a prefix arg
+lets the user choose service."
+  (interactive "MWord: \ni\nP")
+  (let* ((service (or service
+                      (if choose-service
+                          (intern
+                           (completing-read
+                            "Service: " (mapcar #'car define-word-services)))
+                        define-word-default-service)))
+         (servicedata (assoc service define-word-services))
+         (link (format (nth 1 servicedata) (downcase word))))
+    (deferred:$
+      (request-deferred link :parser (nth 2 servicedata))
+      (deferred:nextc it
+        (lambda (response)
+          (if-let ((err (request-response-error-thrown response)))
+              (signal (car err) (cdr err))
+            (apply (or (nth 3 servicedata) #'message)
+                   (request-response-data response))))))))
+
+;;;###autoload
+(defun define-word-at-point (arg &optional service)
   "Use `define-word' to define word at point.
-When the region is active, define the marked phrase."
-  (interactive)
+When the region is active, define the marked phrase.
+Prefix ARG lets you choose service.
+
+In a non-interactive call SERVICE can be passed."
+  (interactive "P")
   (if (use-region-p)
       (define-word
         (buffer-substring-no-properties
          (region-beginning)
-         (region-end)))
+         (region-end))
+        service arg)
     (define-word (substring-no-properties
-                  (thing-at-point 'word)))))
+                  (thing-at-point 'word))
+      service arg)))
+
+(defun define-word--parse-wordnik ()
+  "Parse output from wordnik site and return formatted list"
+  (save-match-data
+    (let (results beg part)
+      (while (re-search-forward "<li><abbr[^>]*>\\([^<]*\\)</abbr>" nil t)
+        (setq part (match-string 1))
+        (unless (= 0 (length part))
+          (setq part (concat part " ")))
+        (skip-chars-forward " ")
+        (setq beg (point))
+        (when (re-search-forward "</li>")
+          (push (concat (propertize part 'face 'font-lock-keyword-face)
+                        (buffer-substring-no-properties beg (match-beginning 0)))
+                results)))
+      (setq results (nreverse results))
+      (cond ((= 0 (length results))
+             (message "0 definitions found"))
+            ((and define-word-unpluralize
+                  (cl-every (lambda (x) (string-match "[Pp]\\(?:lural\\|l\\.\\).*of \\(.*\\)\\." x))
+                            results))
+             (define-word (match-string 1 (car (last results))) 'wordnik)
+             '("Fetching singular..."))
+            (t
+             (when (> (length results) define-word-limit)
+               (setq results (cl-subseq results 0 define-word-limit)))
+             (list (mapconcat #'identity results "\n")))))))
+
+;;; Utility functions
+(defun define-word--strings-in-colums (strings)
+  "Return list of strings in columns
+Responds to the window width as ls should but may not!"
+  ;; adapted from `ls-lisp-column-format' from:
+  ;; https://www.emacswiki.org/emacs/ls-lisp-20.el
+  (with-temp-buffer
+    (let* ((colwid (+ 2 (cl-loop for x in strings
+                                 maximize (length x))))
+           (nstrings (length strings))
+           (fmt (format "%%-%ds" colwid))	; print format
+           (ncols (/ (window-width) colwid)) ; no of columns
+           (collen (/ nstrings ncols)))
+      (if (> nstrings (* collen ncols)) (setq collen (1+ collen)))
+      (let ((i 0) j)
+        (while (< i collen)
+          (setq j i)
+          (while (< j nstrings)
+            (insert (format fmt (nth j strings)))
+            (setq j (+ j collen)))
+          (insert ?\n)
+          (setq i (1+ i)))))
+    (whitespace-cleanup)
+    (buffer-string)))
 
 (provide 'define-word)
 


### PR DESCRIPTION
Quite a large change here, in one commit.

Some abstraction allows the user to add extra services to search through. I’ve been using this myself for a while, but polished it enough to submit it just now.

I changed from `url-retrieve` to `request-deferred` (extra dependency there then) because I thought it was a cleaner way to define parsers and callbacks (and if I don’t remember it wrong, I think I’ve read that it’s usually more stable, when using curl or something).

I have used this for being able to search tyda.se (Swedish-English translations) and thesaurus.com

This one is just a a simple parser + message
https://gitlab.com/andersjohansson/define-word-tyda

This one uses dom and stuff and displays the results in a navigable buffer:
https://gitlab.com/andersjohansson/define-word-thesaurus

This is of course a kind of big change that makes this otherwise very simple library more complex. For me it’s worthwhile but you can think about what you want to do with it.

I don’t know if the ergonomics are that well though out either, I usually call it from a hydra (thank you for that!) anyway:
````emacs-lisp
(defhydra hydra-word-lookup
  (:color blue)
  ("w" sdcv-search "in Webster's")
  ("p" define-word-at-point "word at point")
  ("<RET>" define-word "define word")
  ("t" (define-word (read-from-minibuffer "Tyda: " ) 'tyda) "tyda")
  ("T" (define-word-at-point nil 'tyda) "Tyda at point")
  ("s" (define-word (read-from-minibuffer "Thesaurus: " ) 'thesaurus) "Thesaurus")
  ("S" (define-word-at-point nil 'thesaurus) "Thesaurus at point"))
````
BTW, this PR removes the http-https customization option. But that can of course be customized in the new `define-word-services` variable.
I have also added a utility function (`define-word--strings-in-colums`) which I use for the thesaurus display but which could be useful for more definitions.

Thanks for a useful package this far!