### PR TITLE
Set "results" to return value of parser without redundant setq

### DIFF
--- a/define-word.el
+++ b/define-word.el
@@ -87,7 +87,7 @@ lets the user choose service."
          (link (format (nth 1 servicedata) (downcase word)))
          (results
           (with-current-buffer (url-retrieve-synchronously link t t)
-            (setq results (funcall parser)))))
+            (funcall parser))))
     (if results
         (funcall displayfn results)
       (message "0 definitions found")


### PR DESCRIPTION
The setq is unnecessary because results is automatically set to the last form of with-current-buffer.