### PR TITLE
Retrieve data with custom function

### DIFF
--- a/define-word.el
+++ b/define-word.el
@@ -66,7 +66,8 @@ By default, `message' is used."
     (openthesaurus "https://www.openthesaurus.de/synonyme/%s" define-word--parse-openthesaurus)
     (webster "http://webstersdictionary1828.com/Dictionary/%s" define-word--parse-webster))
   "Services for define-word, A list of lists of the
-  format (symbol url function-for-parsing [function-for-display])"
+  format (symbol url function-for-parsing).
+Instead of an url string, url can be a custom function for retrieving results."
   :type '(alist
           :key-type (symbol :tag "Name of service")
           :value-type (group
@@ -81,10 +82,14 @@ By default, `message' is used."
 (defun define-word--to-string (word service)
   "Get definition of WORD from SERVICE."
   (let* ((servicedata (assoc service define-word-services))
-         (link (format (nth 1 servicedata) (downcase word)))
+         (retriever (nth 1 servicedata))
          (parser (nth 2 servicedata)))
-    (with-current-buffer (url-retrieve-synchronously link t t)
-      (funcall parser))))
+    (if (functionp retriever)
+        (funcall retriever word)
+      (with-current-buffer (url-retrieve-synchronously
+                            (format retriever (downcase word))
+                            t t)
+        (funcall parser)))))
 
 (defun define-word--expand (regex definition service)
   (when (string-match regex definition)


### PR DESCRIPTION
To make [define-word-thesaurus](https://gitlab.com/andersjohansson/define-word-thesaurus) work again after they started to obfuscate their html classes, I have re-used (instead of reimplementing all this in emacs) the python library [thesaurus](https://github.com/Manwholikespie/thesaurus), which does a good job of parsing the html. To be able to call python, I needed to retrive the data via a custom function (invoking a python script) instead of through retrieve-url. These changes allow that.

In define-word-thesaurus I also retrieve the results as a list (instead of a string) to be able to re-use the data for a history of displayed words etc. Thus the small change in `define-word--expand`. Now `define-word--to-string` of course has a slightly misleading name (in the case of some custom backend like define-word-thesaurus using a parser that passes something other than a string to its display function), so perhaps it could also be renamed.

Perhaps these changes are only relevant to define-word-thesaurus, which I have continued to make more and more complex any way (it might be more reasonable to make it an independent package). But if you think the changes are reasonable anyway, feel free to pull!


