### PR TITLE
Wordnik Parse:  Add <i> tag  to regexp search

### DIFF
--- a/define-word.el
+++ b/define-word.el
@@ -165,7 +165,7 @@ In a non-interactive call SERVICE can be passed."
   "Parse output from wordnik site and return formatted list"
   (save-match-data
     (let (results beg part)
-      (while (re-search-forward "<li><abbr[^>]*>\\([^<]*\\)</abbr>" nil t)
+      (while (re-search-forward "<li><abbr[^>]*>\\([^<]*\\)</abbr>\s<i></i>" nil t)
         (setq part (match-string 1))
         (unless (= 0 (length part))
           (setq part (concat part " ")))


### PR DESCRIPTION
Wordnik last update changes its source code by adding an open/close <i> tag. 

Additional tag to Wordnik Parse Regexp search!

Reproducing: 


Word: deluge
result:
```
noun <i></i>  A great flood.
noun <i></i>  A heavy downpour.
noun <i></i>  Something that overwhelms as if by a great flood.
noun <i></i>  In the Bible, the great flood that occurred in the time of Noah.
transitive verb <i></i>  To overrun with water; inundate.
transitive verb <i></i>  To overwhelm with a large number or amount; swamp.
  <i></i>  To pour over in a deluge; overwhelm with a flood; overflow; inundate; drown.
  <i></i>  To overrun like a flood; pour over in overwhelming numbers: as, the northern nations <em>deluged</em> the Roman empire with their armies.
  <i></i>  To overwhelm; cause to sink under the weight of a general or spreading calamity.
  <i></i>  To suffer a deluge; be deluged.
```
-------
Source: view-source:https://www.wordnik.com/words/deluge
Emacs 26.2
Define-word: Version: 0.1.0
